### PR TITLE
not to use AX_FUNC_GETCONTEXT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -203,10 +203,10 @@ AX_LANG_WNOERROR  # end AC_LANG_WERROR
 # Checks for library functions
 #
 
-AX_FUNC_GETCONTEXT
+# AX_FUNC_GETCONTEXT
 AX_FUNC_SIGSETJMP
 
-AC_CHECK_FUNCS([strtoll strtoimax \
+AC_CHECK_FUNCS([getcontext strtoll strtoimax \
                 memalign \
                 fileno getcwd getpagesize])
 


### PR DESCRIPTION
Some architectures has stub for getcontext, so we just use CHECK_FUNCS

Author: NIIBE Yutaka <gniibe@fsij.org>