### PR TITLE
set MAXPATHLEN as 1024

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -65,6 +65,10 @@
 #define FEATURE_ID_SIOD "siod"
 #endif
 
+#if !defined(MAXPATHLEN)
+#define MAXPATHLEN 1024 /* GNU Hurd doesn't have MAXPATHLEN */
+#endif
+
 /*=======================================
   File Local Type Definitions
 =======================================*/


### PR DESCRIPTION
GNU Hurd doesn't have MAXPATHLEN

Author: NIIBE Yutaka <gniibe@fsij.org>