### PR TITLE
m4/ax_check_page_aligned_malloc: Make macros `-Wstrict-prototypes` compatible

### DIFF
--- a/m4/ax_check_page_aligned_malloc.m4
+++ b/m4/ax_check_page_aligned_malloc.m4
@@ -35,7 +35,7 @@ AC_DEFUN([AX_CHECK_PAGE_ALIGNED_MALLOC],
 # include <unistd.h>
 #endif
 
-int main()
+int main(void)
 {
   int pagesize = getpagesize();
   int i;


### PR DESCRIPTION
elimate compiler's warning:

  warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]