### PR TITLE
replace Free Software Foundation (FSF)'s old postal address with URL.

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -207,9 +207,8 @@ test/bigloo-*.scm are licensed under GPL2:
    GNU General Public License for more details.                      
                                                                      
    You should have received a copy of the GNU General Public         
-   License along with this program; if not, write to the Free        
-   Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,   
-   MA 02111-1307, USA.                                               
+   License along with this program; if not, see
+   <https://www.gnu.org/licenses/>.
 ---------------------------------------------------------------------
 
 
@@ -227,10 +226,8 @@ test/scm-r4rstest.scm is licensed under GPL2:
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 ;;
-;; To receive a copy of the GNU General Public License, write to the
-;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-;; Boston, MA 02111-1307, USA; or view
-;; http://swiss.csail.mit.edu/~jaffer/GPL.html
+;; To receive a copy of the GNU General Public License, see
+;; <https://www.gnu.org/licenses/>.
 -----------------------------------------------------------------------------
 
 

--- a/test/bigloo-apply.scm
+++ b/test/bigloo-apply.scm
@@ -33,10 +33,8 @@
 ;;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the     
 ;;   GNU General Public License for more details.                      
 ;;                                                                     
-;;   You should have received a copy of the GNU General Public         
-;;   License along with this program; if not, write to the Free        
-;;   Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,   
-;;   MA 02111-1307, USA.                                               
+;;   You should have received a copy of the GNU General Public License
+;;   along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 ;*---------------------------------------------------------------------*/
 ;*    serrano/prgm/project/bigloo/recette/apply.scm                    */

--- a/test/bigloo-bchar.scm
+++ b/test/bigloo-bchar.scm
@@ -35,10 +35,8 @@
 ;;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the     
 ;;   GNU General Public License for more details.                      
 ;;                                                                     
-;;   You should have received a copy of the GNU General Public         
-;;   License along with this program; if not, write to the Free        
-;;   Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,   
-;;   MA 02111-1307, USA.                                               
+;;   You should have received a copy of the GNU General Public License
+;;   along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 ;*---------------------------------------------------------------------*/
 ;*    serrano/prgm/project/bigloo/recette/bchar.scm                    */

--- a/test/bigloo-bool.scm
+++ b/test/bigloo-bool.scm
@@ -33,10 +33,8 @@
 ;;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the     
 ;;   GNU General Public License for more details.                      
 ;;                                                                     
-;;   You should have received a copy of the GNU General Public         
-;;   License along with this program; if not, write to the Free        
-;;   Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,   
-;;   MA 02111-1307, USA.                                               
+;;   You should have received a copy of the GNU General Public License
+;;   along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 ;*---------------------------------------------------------------------*/
 ;*    serrano/prgm/project/bigloo/recette/bool.scm                     */

--- a/test/bigloo-case.scm
+++ b/test/bigloo-case.scm
@@ -33,10 +33,8 @@
 ;;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the     
 ;;   GNU General Public License for more details.                      
 ;;                                                                     
-;;   You should have received a copy of the GNU General Public         
-;;   License along with this program; if not, write to the Free        
-;;   Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,   
-;;   MA 02111-1307, USA.                                               
+;;   You should have received a copy of the GNU General Public License
+;;   along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 ;*---------------------------------------------------------------------*/
 ;*    serrano/prgm/project/bigloo/recette/case.scm                     */

--- a/test/bigloo-letrec.scm
+++ b/test/bigloo-letrec.scm
@@ -33,10 +33,8 @@
 ;;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the     
 ;;   GNU General Public License for more details.                      
 ;;                                                                     
-;;   You should have received a copy of the GNU General Public         
-;;   License along with this program; if not, write to the Free        
-;;   Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,   
-;;   MA 02111-1307, USA.                                               
+;;   You should have received a copy of the GNU General Public License
+;;   along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 ;*---------------------------------------------------------------------*/
 ;*    serrano/prgm/project/bigloo/recette/letrec.scm                   */

--- a/test/bigloo-list.scm
+++ b/test/bigloo-list.scm
@@ -33,10 +33,8 @@
 ;;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the     
 ;;   GNU General Public License for more details.                      
 ;;                                                                     
-;;   You should have received a copy of the GNU General Public         
-;;   License along with this program; if not, write to the Free        
-;;   Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,   
-;;   MA 02111-1307, USA.                                               
+;;   You should have received a copy of the GNU General Public License
+;;   along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 ;*---------------------------------------------------------------------*/
 ;*    serrano/prgm/project/bigloo/recette/list.scm                     */

--- a/test/bigloo-quote.scm
+++ b/test/bigloo-quote.scm
@@ -33,10 +33,8 @@
 ;;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the     
 ;;   GNU General Public License for more details.                      
 ;;                                                                     
-;;   You should have received a copy of the GNU General Public         
-;;   License along with this program; if not, write to the Free        
-;;   Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,   
-;;   MA 02111-1307, USA.                                               
+;;   You should have received a copy of the GNU General Public License
+;;   along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 ;*---------------------------------------------------------------------*/
 ;*    serrano/prgm/project/bigloo/recette/kwote.scm                    */

--- a/test/bigloo-vector.scm
+++ b/test/bigloo-vector.scm
@@ -33,10 +33,8 @@
 ;;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the     
 ;;   GNU General Public License for more details.                      
 ;;                                                                     
-;;   You should have received a copy of the GNU General Public         
-;;   License along with this program; if not, write to the Free        
-;;   Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,   
-;;   MA 02111-1307, USA.                                               
+;;   You should have received a copy of the GNU General Public License
+;;   along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 ;*---------------------------------------------------------------------*/
 ;*    serrano/prgm/project/bigloo/recette/vector.scm                   */

--- a/test/scm-r4rstest.scm
+++ b/test/scm-r4rstest.scm
@@ -10,10 +10,8 @@
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 ;;
-;; To receive a copy of the GNU General Public License, write to the
-;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-;; Boston, MA 02111-1307, USA; or view
-;; http://swiss.csail.mit.edu/~jaffer/GPL.html
+;; To receive a copy of the GNU General Public License, see
+;; <https://www.gnu.org/licenses/>.
 
 ;;;;"r4rstest.scm":  Test R4RS correctness of scheme implementations.
 ;;; Author:          Aubrey Jaffer


### PR DESCRIPTION
This is their previous address. It is pointed by Lintian (https://lintian.debian.org/tags/old-fsf-address-in-copyright-file.html).